### PR TITLE
PR 3, DND-899

### DIFF
--- a/src/2_FSD_pages/ChooseTrainPage/components/ChooseTrainPage/ChooseTrain.page.tsx
+++ b/src/2_FSD_pages/ChooseTrainPage/components/ChooseTrainPage/ChooseTrain.page.tsx
@@ -1,18 +1,23 @@
 import { getRouteChooseTrain } from "@config/router"
 import { BreadcrumbsLine } from "@features/BreadcrumbsLine"
+import { useFormForSearchDirectionsActions } from "@features/FillingFormForSearchOfDirections"
 import { LastTickets } from "@features/LastTickets"
 import { useAppDispatch } from "@hooks/useAppDispatch.hook"
 import { ContainerLayout } from "@ui/layout"
 import { Page } from "@ui/Page"
 import { HStack, VStack } from "@ui/Stack"
 import { DirectionsList } from "@widgets/DirectionsList"
-import { DisplaySettingsDirectionsList } from "@widgets/DisplaySettingsDirectionsList"
-import { fetchDirectionsListThunk } from "@widgets/DisplaySettingsDirectionsList/store/thunks/fetchDirectionsListThunk/fetchDirectionsList.thunk"
+import {
+	DisplaySettingsDirectionsList,
+	fetchDirectionsListThunk,
+	fetchInitialDirectionListThunk
+} from "@widgets/DisplaySettingsDirectionsList"
 import { FilterDirections } from "@widgets/FilterDirections"
 import { Footer } from "@widgets/Footer"
 import { Header } from "@widgets/Header"
 import { SearchDirections } from "@widgets/SearchDirections"
 import { memo, useCallback, useEffect, useMemo } from "react"
+import { useSearchParams } from "react-router-dom"
 import styles from "./ChooseTrain.module.scss"
 
 const pagePath = getRouteChooseTrain()
@@ -23,11 +28,17 @@ const ChooseTrainPage = memo(() => {
 	const onSearchHandler = useCallback(() => {
 		dispatch(fetchDirectionsListThunk())
 	}, [dispatch])
+	const { clearParametres } = useFormForSearchDirectionsActions()
+
+	const [searchParams] = useSearchParams()
 
 	useEffect(() => {
-		onSearchHandler()
-		//eslint-disable-next-line
-	}, [])
+		dispatch(fetchInitialDirectionListThunk(searchParams))
+
+		return () => {
+			clearParametres()
+		}
+	}, [clearParametres, dispatch, searchParams])
 
 	const contentPage = (
 		<>

--- a/src/2_FSD_pages/MainPage/components/MainPage/ui/HeaderContent/HeaderContent.tsx
+++ b/src/2_FSD_pages/MainPage/components/MainPage/ui/HeaderContent/HeaderContent.tsx
@@ -1,6 +1,8 @@
 import { TitleIcon } from "@assets/index"
 import { getRouteChooseTrain } from "@config/router"
+import { useGetFormForSearchOfDirectionsDataForRequestSelector } from "@features/FillingFormForSearchOfDirections"
 import { classNamesHelp } from "@helpers/classNamesHelp/classNamesHelp"
+import { createQueryParams } from "@helpers/createLinkWithParams/createLinkWithParams.helper"
 import { HStack } from "@ui/Stack"
 import { SearchDirections } from "@widgets/SearchDirections"
 import { memo, useCallback } from "react"
@@ -15,9 +17,11 @@ export const HeaderContent = memo<HeaderContentProps>(props => {
 
 	const navigate = useNavigate()
 
+	const formParametres = useGetFormForSearchOfDirectionsDataForRequestSelector()
+
 	const onSearchHandler = useCallback(() => {
-		navigate(getRouteChooseTrain().route)
-	}, [navigate])
+		navigate(createQueryParams(getRouteChooseTrain().route, formParametres))
+	}, [formParametres, navigate])
 
 	return (
 		<HStack

--- a/src/3_FSD_widgets/DisplaySettingsDirectionsList/index.ts
+++ b/src/3_FSD_widgets/DisplaySettingsDirectionsList/index.ts
@@ -1,1 +1,3 @@
 export { DisplaySettingsDirectionsList } from "./components/DisplaySettingsDirectionsList/DisplaySettingsDirectionsList"
+export { fetchDirectionsListThunk } from "./store/thunks/fetchDirectionsListThunk/fetchDirectionsList.thunk"
+export { fetchInitialDirectionListThunk } from "./store/thunks/fetchInitialDirectionList/fetchInitialDirectionList.thunk"

--- a/src/3_FSD_widgets/DisplaySettingsDirectionsList/store/thunks/fetchDirectionsListThunk/fetchDirectionsList.thunk.ts
+++ b/src/3_FSD_widgets/DisplaySettingsDirectionsList/store/thunks/fetchDirectionsListThunk/fetchDirectionsList.thunk.ts
@@ -1,10 +1,15 @@
 // To Hold: написать тест
 
-import { fetchDirectionsThunk } from "@entities/Direction"
+import {
+	directionsListSliceActions,
+	fetchDirectionsThunk,
+	getDirectionsListIsInitSelector
+} from "@entities/Direction"
 import {
 	getFormForSearchOfDirectionsDataForRequestSelector,
 	getFormForSearchOfDirectionsIsValidFormSelector
 } from "@features/FillingFormForSearchOfDirections/store/selectors/getFormForSearchOfDirectionsProperty/getFormForSearchOfDirectionsProperty.selector"
+import { addQueryParams } from "@helpers/addQueryParams/addQueryParams.helper"
 import { createAsyncThunk } from "@reduxjs/toolkit"
 import type { thunkConfigType } from "@store/storeTypes/thunks.type"
 
@@ -12,13 +17,21 @@ export const fetchDirectionsListThunk = createAsyncThunk<
 	undefined,
 	undefined,
 	thunkConfigType<undefined>
->("DisplaySettingsDirectionsList/fetchDirectionsList", async (parametres, thunkAPI) => {
+>("DisplaySettingsDirectionsList/fetchDirectionsList", async (_, thunkAPI) => {
 	const { dispatch, getState } = thunkAPI
 
 	const isValid = getFormForSearchOfDirectionsIsValidFormSelector()(getState())
 	const formParametres = getFormForSearchOfDirectionsDataForRequestSelector()(getState())
+	const isInit = getDirectionsListIsInitSelector()(getState())
 
+	const { directionsListInit } = directionsListSliceActions
 	if (isValid && formParametres) {
+		if (isInit) {
+			addQueryParams(formParametres)
+		} else {
+			dispatch(directionsListInit())
+		}
+
 		dispatch(fetchDirectionsThunk(formParametres))
 	}
 

--- a/src/3_FSD_widgets/DisplaySettingsDirectionsList/store/thunks/fetchInitialDirectionList/fetchInitialDirectionList.thunk.ts
+++ b/src/3_FSD_widgets/DisplaySettingsDirectionsList/store/thunks/fetchInitialDirectionList/fetchInitialDirectionList.thunk.ts
@@ -1,0 +1,23 @@
+import { parseFormDataFromUrlHelper } from "@features/FillingFormForSearchOfDirections/lib/helpers/parseFormDataFromUrl/parseFormDataFromUrl.helper"
+import { formForSearchDirectionsActions } from "@features/FillingFormForSearchOfDirections/store/slices/formForSearchOfDirections.slice"
+import { createAsyncThunk } from "@reduxjs/toolkit"
+import type { thunkConfigType } from "@store/storeTypes/thunks.type"
+import { fetchDirectionsListThunk } from "../fetchDirectionsListThunk/fetchDirectionsList.thunk"
+
+export const fetchInitialDirectionListThunk = createAsyncThunk<
+	undefined,
+	URLSearchParams | undefined,
+	thunkConfigType<undefined>
+>("DisplaySettingsDirectionsList/fetchInitialDirectionList", (searchParams, thunkAPI) => {
+	const { dispatch } = thunkAPI
+
+	const [formData, displayData] = parseFormDataFromUrlHelper(searchParams)
+
+	const { setParametres, setDisplayParametres } = formForSearchDirectionsActions
+
+	dispatch(setParametres(formData))
+	dispatch(setDisplayParametres(displayData))
+	dispatch(fetchDirectionsListThunk())
+
+	return undefined
+})

--- a/src/4_FSD_features/FillingFormForSearchOfDirections/lib/helpers/parseFormDataFromUrl/parseFormDataFromUrl.helper.ts
+++ b/src/4_FSD_features/FillingFormForSearchOfDirections/lib/helpers/parseFormDataFromUrl/parseFormDataFromUrl.helper.ts
@@ -1,0 +1,45 @@
+import type { directionDisplayParametres } from "@entities/Direction"
+import type { formDataType } from "../../../store/storeTypes/formForSearchOfDirectionsState.map"
+
+export function parseFormDataFromUrlHelper(
+	searchParams?: URLSearchParams
+): [formDataType, directionDisplayParametres] {
+	let formData = {}
+	let displayData = {}
+
+	searchParams?.forEach((value, key) => {
+		let formParam = {}
+		const keyCity = key === "from_city_id" ? "fromCity" : "toCity"
+
+		switch (key) {
+			case "from_city_id":
+			case "to_city_id":
+				formParam = {
+					[keyCity]: {
+						_id: value,
+						name: ""
+					}
+				}
+
+				formData = { ...formData, ...formParam }
+				break
+			case "limit":
+			case "offset":
+				formParam = {
+					[key]: parseInt(value)
+				}
+
+				displayData = { ...displayData, ...formParam }
+				break
+			default:
+				formParam = {
+					[key]: value
+				}
+
+				formData = { ...formData, ...formParam }
+				break
+		}
+	})
+
+	return [formData, displayData]
+}

--- a/src/4_FSD_features/FillingFormForSearchOfDirections/lib/helpers/parseFormDataFromUrl/parseFormDataFromUrlHelper.test.ts
+++ b/src/4_FSD_features/FillingFormForSearchOfDirections/lib/helpers/parseFormDataFromUrl/parseFormDataFromUrlHelper.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "@jest/globals"
+import { parseFormDataFromUrlHelper } from "./parseFormDataFromUrl.helper"
+
+describe("parseFormDataFromUrlHelperTest", () => {
+	test("only form data", () => {
+		const searchParams = new URLSearchParams(
+			"?from_city_id=66ac8b69cb563f0052174f45&to_city_id=66ac8b69cb563f0052174f46"
+		)
+		expect(parseFormDataFromUrlHelper(searchParams)).toEqual([
+			{
+				fromCity: {
+					_id: "66ac8b69cb563f0052174f45",
+					name: ""
+				},
+				toCity: {
+					_id: "66ac8b69cb563f0052174f46",
+					name: ""
+				}
+			},
+			{}
+		])
+	})
+	test("only display data", () => {
+		const searchParams = new URLSearchParams("?limit=5&offset=10")
+		expect(parseFormDataFromUrlHelper(searchParams)).toEqual([
+			{},
+			{
+				limit: 5,
+				offset: 10
+			}
+		])
+	})
+
+	test("both data", () => {
+		const searchParams = new URLSearchParams(
+			"?from_city_id=66ac8b69cb563f0052174f45&to_city_id=66ac8b69cb563f0052174f46&limit=5&offset=10"
+		)
+		expect(parseFormDataFromUrlHelper(searchParams)).toEqual([
+			{
+				fromCity: {
+					_id: "66ac8b69cb563f0052174f45",
+					name: ""
+				},
+				toCity: {
+					_id: "66ac8b69cb563f0052174f46",
+					name: ""
+				}
+			},
+			{
+				limit: 5,
+				offset: 10
+			}
+		])
+	})
+
+	test("nothing data", () => {
+		const searchParams = new URLSearchParams("?")
+
+		expect(parseFormDataFromUrlHelper(searchParams)).toEqual([{}, {}])
+	})
+})

--- a/src/5_FSD_entities/City/api/getCitiesByPattern.rtkq.ts
+++ b/src/5_FSD_entities/City/api/getCitiesByPattern.rtkq.ts
@@ -11,21 +11,11 @@ const getCitiesByPatternRtkq = rtkBaseApi.injectEndpoints({
 				}
 			},
 			keepUnusedDataFor: 1
-			// transformResponse: (
-			// 	response: {
-			// 		_id: cityDataType["_id"]
-			// 		name: cityDataType["name"]
-			// 	}[]
-			// ) => {
-			// 	if (response.length) {
-			// 		return response.map(city => ({ id: city._id, name: city.name }))
-			// 	}
-			//
-			// 	return []
-			// }
 		})
 	})
 })
 
 export const { useGetCitiesByPatternQuery } = getCitiesByPatternRtkq
 export const getCitiesByPattern = getCitiesByPatternRtkq.endpoints.getCitiesByPattern.initiate
+
+// To Feature оптимизировать запрос. Удаление неактуальных.

--- a/src/5_FSD_entities/Direction/index.ts
+++ b/src/5_FSD_entities/Direction/index.ts
@@ -13,6 +13,7 @@ export { fetchDirectionsThunk } from "./store/thunks/fetchDirections/fetchDirect
 
 export {
 	directionsListSliceReducers,
+	directionsListSliceActions,
 	useDirectionsListSliceUseActions
 } from "./store/slices/directionsList.slice"
 
@@ -21,7 +22,9 @@ export {
 	useGetDirectionsListIsLoadingSelector,
 	useGetDirectionsListDataSelector,
 	useGetDirectionsListItemSelector,
-	useGetDirectionsListTotalCountSelector
+	useGetDirectionsListTotalCountSelector,
+	useGetDirectionsListIsInitSelector,
+	getDirectionsListIsInitSelector
 } from "./store/selectors/getDirectionsListProperties/getDirectionsListProperties.selector"
 
 export { DirectionCard } from "./components/DirectionCard/DirectionCard"

--- a/src/5_FSD_entities/Direction/store/selectors/getDirectionsListProperties/getDirectionsListProperties.selector.ts
+++ b/src/5_FSD_entities/Direction/store/selectors/getDirectionsListProperties/getDirectionsListProperties.selector.ts
@@ -5,6 +5,12 @@ import { directionsListAdapter } from "../../slices/directionsList.slice"
 import type { directionsListStateMap } from "../../storeTypes/directionsListState.map"
 import { getDirectionsListSelector } from "../getDirectionsList/getDirectionsList.selector"
 
+export const [useGetDirectionsListIsInitSelector, getDirectionsListIsInitSelector] =
+	buildCreateSelector(
+		[getDirectionsListSelector],
+		(state?: directionsListStateMap) => state?._inited || false
+	)
+
 export const [useGetDirectionsListIsLoadingSelector, getDirectionsListIsLoadingSelector] =
 	buildCreateSelector(
 		[getDirectionsListSelector],

--- a/src/5_FSD_entities/Direction/store/selectors/getDirectionsListProperties/getDirectionsListPropertiesSelector.test.ts
+++ b/src/5_FSD_entities/Direction/store/selectors/getDirectionsListProperties/getDirectionsListPropertiesSelector.test.ts
@@ -4,10 +4,27 @@ import type { mainStateMap } from "@store/storeTypes/mainState.map"
 import {
 	getDirectionsListDataSelector,
 	getDirectionsListErrorSelector,
+	getDirectionsListIsInitSelector,
 	getDirectionsListIsLoadingSelector,
 	getDirectionsListItemSelector,
 	getDirectionsListTotalCountSelector
 } from "./getDirectionsListProperties.selector"
+
+describe("getDirectionsListIsInitSelector", () => {
+	test("get state", () => {
+		const state: DeepPartial<mainStateMap> = {
+			directionsList: {
+				_inited: true
+			}
+		}
+		expect(getDirectionsListIsInitSelector()(state as mainStateMap)).toBe(true)
+	})
+
+	test("get withOut state", () => {
+		const state: DeepPartial<mainStateMap> = {}
+		expect(getDirectionsListIsInitSelector()(state as mainStateMap)).toBe(false)
+	})
+})
 
 describe("getDirectionsListIsLoadingSelector", () => {
 	test("get state", () => {

--- a/src/6_FSD_shared/lib/helpers/addQueryParams/addQueryParams.helper.ts
+++ b/src/6_FSD_shared/lib/helpers/addQueryParams/addQueryParams.helper.ts
@@ -1,6 +1,6 @@
-export type paramsType<T extends string | number> = Record<string, T>
+import type { paramsType } from "@customTypes/common.types"
 
-export function createQueryParams<T extends string | number>(params?: paramsType<T>) {
+export function createQueryParams<T extends string | number | boolean>(params?: paramsType<T>) {
 	const searchParams = new URLSearchParams(window.location.search)
 
 	if (!params) return null
@@ -14,6 +14,6 @@ export function createQueryParams<T extends string | number>(params?: paramsType
 	return `?${searchParams}`
 }
 
-export function addQueryParams<T extends string | number>(params?: paramsType<T>) {
+export function addQueryParams<T extends string | number | boolean>(params?: paramsType<T>) {
 	window.history.pushState(undefined, "", createQueryParams(params))
 }

--- a/src/6_FSD_shared/lib/helpers/createLinkWithParams/createLinkWithParams.helper.ts
+++ b/src/6_FSD_shared/lib/helpers/createLinkWithParams/createLinkWithParams.helper.ts
@@ -1,0 +1,18 @@
+import { type paramsType } from "@customTypes/common.types"
+
+export function createQueryParams<T extends string | number | boolean>(
+	link: string,
+	params: paramsType<T>
+) {
+	let linkResult = link
+
+	Object.entries(params).forEach(([key, value], i) => {
+		if (i === 0) {
+			linkResult = `${linkResult}?${key}=${value}`
+		} else {
+			linkResult = `${linkResult}&${key}=${value}`
+		}
+	})
+
+	return linkResult
+}

--- a/src/6_FSD_shared/lib/helpers/createLinkWithParams/createLinkWithParamsHelper.test.ts
+++ b/src/6_FSD_shared/lib/helpers/createLinkWithParams/createLinkWithParamsHelper.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "@jest/globals"
+import { createQueryParams } from "./createLinkWithParams.helper"
+
+describe("createLinkWithParamsHelperTest", () => {
+	test("with one parametres", () => {
+		expect(createQueryParams("/", { test: "test1" })).toBe("/?test=test1")
+	})
+
+	test("with multiple parametres", () => {
+		expect(createQueryParams("/", { test: "test1", test1: 2, test2: true })).toBe(
+			"/?test=test1&test1=2&test2=true"
+		)
+	})
+})

--- a/src/6_FSD_shared/lib/hooks/useInitialEffect.hook.ts
+++ b/src/6_FSD_shared/lib/hooks/useInitialEffect.hook.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react"
+
+export const useInitialEffect = (callback: () => void, returnCallback?: () => void) => {
+	useEffect(() => {
+		callback()
+
+		return () => {
+			returnCallback?.()
+		}
+		//eslint-disable-next-line
+	}, [])
+}

--- a/src/6_FSD_shared/types/common.types.ts
+++ b/src/6_FSD_shared/types/common.types.ts
@@ -1,1 +1,3 @@
 export type showLimit = 5 | 10 | 20
+
+export type paramsType<T extends string | number | boolean> = Record<string, T>

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,13 +1,13 @@
 import App from "@app/App"
 import { StoreProvider } from "@providers/StoreProvider"
-import { HashRouter } from "react-router-dom"
+import { BrowserRouter } from "react-router-dom"
 
 export const RootComponent = () => {
 	return (
-		<HashRouter>
+		<BrowserRouter>
 			<StoreProvider>
 				<App />
 			</StoreProvider>
-		</HashRouter>
+		</BrowserRouter>
 	)
 }


### PR DESCRIPTION
Переезжал с yarn на pnpm, поэтому в данном коммите уже самый свежий функционал, и могут не работать github actions.

Из-за переезда на новый пакетный менеджер проверку функционала, который реализовал, но не был проверен - решил пропустить, и в этом PR только одна самая новая фича.

Добавил сохранение парметров поиска в URL.
- При обновлении страницы посылается новый запрос на по тем данным, что сохранены в url. При уходе ос страницы state формы - сбрасывается.